### PR TITLE
downgrade lxml as can't install it on the build machine

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps =
     py27: mock
     flake8
     pytest-django
-    lxml
+    lxml==3.6.4
     cssselect
     docutils
 whitelist_externals = make


### PR DESCRIPTION
likely due to missing wheel packages, see

https://bugs.launchpad.net/lxml?field.searchtext=wheel&search=Search&field.status%3Alist=NEW&field.status%3Alist=INCOMPLETE_WITH_RESPONSE&field.status%3Alist=INCOMPLETE_WITHOUT_RESPONSE&field.status%3Alist=CONFIRMED&field.status%3Alist=TRIAGED&field.status%3Alist=INPROGRESS&field.status%3Alist=FIXCOMMITTED&field.assignee=&field.bug_reporter=&field.omit_dupes=on&field.has_patch=&field.has_no_package=