### PR TITLE
Fix for issue #10 (AttributeError: NoneType for lang)

### DIFF
--- a/django_admin_caching/caching.py
+++ b/django_admin_caching/caching.py
@@ -53,9 +53,13 @@ class CacheKey(object):
 
     @property
     def i18n_l10n_prefix(self):
-        lang = translation.get_language()
-        locale = translation.to_locale(lang)
         parts = []
+        lang = translation.get_language()
+        if lang is None:
+            lang = ''
+            locale = ''
+        else:
+            locale = translation.to_locale(lang)
         if settings.USE_I18N:
             parts += [lang]
         if settings.USE_L10N:

--- a/tests/testapp/tests/test_cache_key.py
+++ b/tests/testapp/tests/test_cache_key.py
@@ -1,6 +1,7 @@
 from django.contrib.admin.sites import site
 from django.contrib.auth.models import Group
 from django.contrib.sessions.models import Session
+from django.utils import translation
 from django_admin_caching.caching import CacheKey
 import pytest
 from testapp.test_helpers import translation_being
@@ -72,3 +73,12 @@ def test_key_is_i18n_l10n_aware_if_settings_enabled(settings, language, i18n,
         assert ck.key.startswith(expected_key_prefix)
         if expected_key_prefix:
             assert ck.key.startswith('{}.'.format(expected_key_prefix))
+
+
+def test_when_all_language_is_deactivated(settings):
+    settings.USE_I18N = True
+    settings.USE_L10N = True
+    with translation_being('en'):
+        translation.deactivate_all()
+        ck = CacheKey(result=Group(pk=1))
+        _ = ck.i18n_l10n_prefix


### PR DESCRIPTION
In case `translation.deactivate_all()` from `django.utils` has been called, `translation.get_language()` returns `None`. This caused an error in the [`i18n_l10n_prefix`](https://github.com/PaesslerAG/django-admin-caching/blob/f851b52b1547f445b80cfe4d5e087856b5b493cd/django_admin_caching/caching.py#L57) method.

This pull request contains a test which examines exactly this case and a simple fix for it.