### PR TITLE
Lint: no bare 'except'

### DIFF
--- a/tests/testapp/sixmocks.py
+++ b/tests/testapp/sixmocks.py
@@ -1,4 +1,4 @@
 try:
     from unittest.mock import patch, Mock, DEFAULT, call  # noqa: F401
-except:
+except ImportError:
     from mock import patch, Mock, DEFAULT, call  # noqa: F401


### PR DESCRIPTION
The latest lint package fails the build with that.